### PR TITLE
feat(github-workflows): Notion 이슈 업데이트 워크플로우 추가

### DIFF
--- a/.github/workflows/notion_issue.yml
+++ b/.github/workflows/notion_issue.yml
@@ -1,0 +1,39 @@
+name: GitHub Issue 생성 시 Notion에 등록
+
+on:
+  issues:
+    types: [opened, edited, closed]
+
+jobs:
+  노션_이슈_업데이트:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Notion에 Issue 추가
+        run: |
+          curl -X POST "https://api.notion.com/v1/pages" \
+          -H "Authorization: Bearer ${{ secrets.NOTION_API_KEY }}" \
+          -H "Notion-Version: 2022-06-28" \
+          -H "Content-Type: application/json" \
+          --data '{
+            "parent": { "database_id": "${{ secrets.NOTION_DATABASE_ID }}" },
+            "properties": {
+              "작업": { 
+                "title": [{ "text": { "content": "${{ github.event.issue.title }}" }}] 
+              },
+              "기능명": { 
+                "rich_text": [{ "text": { "content": "${{ github.event.issue.body }}" }}] 
+              },
+              "Status": { 
+                "status": { "name": "시작 전" } 
+              },
+              "GitHub 풀 리퀘스트": {
+                "relation": [] 
+              },
+              "담당자": { 
+                "people": [{ "id": "${{ github.event.issue.user.id }}" }] 
+              },
+              "생성 날짜": { 
+                "date": { "start": "${{ github.event.issue.created_at }}" } 
+              }
+            }
+          }'

--- a/.github/workflows/notion_issue.yml
+++ b/.github/workflows/notion_issue.yml
@@ -5,7 +5,7 @@ on:
     types: [opened, edited, closed]
 
 jobs:
-  노션_이슈_업데이트:
+  notion_issue_update:
     runs-on: ubuntu-latest
     steps:
       - name: Notion에 Issue 추가

--- a/.github/workflows/notion_pr.yml
+++ b/.github/workflows/notion_pr.yml
@@ -1,0 +1,26 @@
+name: GitHub PR 생성 시 Notion 업데이트
+
+on:
+  pull_request:
+    types: [opened, closed, merged]
+
+jobs:
+  노션_PR_업데이트:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Notion에 PR 정보 업데이트
+        run: |
+          curl -X PATCH "https://api.notion.com/v1/pages/${{ secrets.NOTION_PR_PAGE_ID }}" \
+          -H "Authorization: Bearer ${{ secrets.NOTION_API_KEY }}" \
+          -H "Notion-Version: 2022-06-28" \
+          -H "Content-Type: application/json" \
+          --data '{
+            "properties": {
+              "GitHub 풀 리퀘스트": {
+                "relation": [{ "id": "${{ github.event.pull_request.id }}" }]
+              },
+              "Status": { 
+                "status": { "name": "${{ github.event.pull_request.state }}" } 
+              }
+            }
+          }'

--- a/.github/workflows/notion_pr.yml
+++ b/.github/workflows/notion_pr.yml
@@ -5,7 +5,7 @@ on:
     types: [opened, closed, merged]
 
 jobs:
-  노션_PR_업데이트:
+  notion_pr_update:
     runs-on: ubuntu-latest
     steps:
       - name: Notion에 PR 정보 업데이트


### PR DESCRIPTION
- GitHub 이슈 생성, 수정, 닫힘 이벤트 발생 시 Notion에 동기화하는 기능 추가
- Notion API를 활용하여 이슈 정보를 Notion 데이터베이스에 업데이트
- 이슈 제목, 내용, 상태, 담당자, 생성 날짜 등의 정보를 Notion에 등록